### PR TITLE
chore: Fix broken links to within scope defintion

### DIFF
--- a/index.html
+++ b/index.html
@@ -364,7 +364,7 @@
             <ol>
               <li>Let |apps:set of applications| be the [=set=] of [=installed
               web applications=] such that |document|'s {{Document/URL}} is
-              <a data-cite="appmanifest#dfn-within-scope-manifest">within
+              <a data-cite="appmanifest#dfn-within-scope">within
               scope</a> of the application's manifest. (Order is not
               important.)
               </li>
@@ -380,7 +380,7 @@
             <ol>
               <li>Return the [=set=] of [=installed web applications=] whose
               [=manifest/navigation scope=] is <a data-cite=
-              "appmanifest#dfn-within-scope-manifest">within scope</a> (as
+              "appmanifest#dfn-within-scope">within scope</a> (as
               defined in [[AppManifest]]) of |environment|'s [=service
               worker/containing service worker registration=]'s [=service
               worker registration/scope url=]. (Order is not important.)


### PR DESCRIPTION
Fixes #89

Quick change to URLs citing the "within scope" definition. Now points to https://www.w3.org/TR/appmanifest/#dfn-within-scope


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/NotWoods/badging/pull/90.html" title="Last updated on Oct 16, 2022, 11:07 PM UTC (f924f02)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/badging/90/16fd808...NotWoods:f924f02.html" title="Last updated on Oct 16, 2022, 11:07 PM UTC (f924f02)">Diff</a>