### PR TITLE
Spec rewrite to address open issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,14 @@
           name: "Matt Giuca",
           company: "Google Inc.",
           companyURL: "https://google.com"
-        }, {
+        },
+        {
+          name: "Marcos Cáceres",
+          company: "Apple Inc.",
+          companyURL: "https://apple.com",
+          w3cid: 78903
+        },
+        {
           name: "Jay Harris",
           retiredDate: "2019-12-31"
         }],
@@ -29,16 +36,13 @@
       };
     </script>
   </head>
-  <body data-cite="appmanifest service-workers">
+  <body data-cite="appmanifest">
     <section id="abstract">
       <p>
-        This specification defines an API allowing web pages and [=installed
-        web applications=] to set a badge on the document, or an
-        application-wide badge, shown in an operating-system-specific place
-        associated with the application (such as the shelf or home screen), for
-        the purpose of notifying the user when the state of the page or
-        application has changed (e.g., when new messages have arrived), without
-        showing a more heavyweight notification.
+        This specification defines an API allowing [=installed web
+        applications=] to set an application badge, which is usually shown in
+        an operating-system-specific place associated with the application
+        (such as the shelf, dock, or home screen).
       </p>
     </section>
     <section id="sotd">
@@ -50,44 +54,6 @@
       <h2>
         Usage examples
       </h2>
-      <p>
-        The following example shows how an email application might set a badge
-        showing the unread count associated with the current document, which is
-        updated whenever the client polls for mail from the server.
-      </p>
-      <pre class="example javascript" title=
-      "Showing unread count for this document">
-        function pollForMail() {
-          // ... Fetch unread mail from server. ...
-
-          // Set the document badge. If getUnreadCount() returns 0, this is
-          // equivalent to navigator.clearClientBadge().
-          navigator.setClientBadge(getUnreadCount());
-        }
-      </pre>
-      <p>
-        The next example shows how a game might show when it is the player's
-        turn. Again, this associates the badge with the current document.
-      </p>
-      <pre class="example javascript" title=
-      "Showing ready status for this document">
-        function showPlayerTurn(playerTurnId) {
-          if (playerTurnId === localPlayerId)
-            navigator.setClientBadge();
-          else
-            navigator.clearClientBadge();
-        }
-      </pre>
-      <p>
-        A separate set of methods set the badge on the [=installed web
-        application=], if any, whose [=manifest/navigation scope=] this
-        document is within. The badge might show up on the application's icon
-        in the operating system shelf. These examples work the same as above,
-        except that the badge has global scope (if multiple documents within
-        the same application set or clear a badge, the most recent one takes
-        effect), and can continue being seen even after the last document
-        closes.
-      </p>
       <pre class="example javascript" title=
       "Showing unread count on the app icon">
         function pollForMail() {
@@ -97,6 +63,12 @@
           navigator.setAppBadge(getUnreadCount());
         }
       </pre>
+      <p>
+        The badge might show up on the application's icon in the operating
+        system. If multiple API calls within the same application [=set=] or
+        [=clear=] a badge, the most recent one takes effect, and may continue
+        being seen even after an application is closed.
+      </p>
       <pre class="example javascript" title=
       "Showing ready status on the app icon">
         function showPlayerTurn(playerTurnId) {
@@ -106,294 +78,173 @@
             navigator.clearAppBadge();
         }
       </pre>
-      <p>
-        To show a badge on both the document(s) and app icon(s), use both APIs
-        together.
-      </p>
     </section>
     <section>
       <h2>
         Badge model
       </h2>
       <p>
-        A <dfn>badge</dfn> may be one of the following values:
-      </p>
-      <ul>
-        <li>The special value <dfn>nothing</dfn>, which indicates that there is
-        no badge currently set.
-        </li>
-        <li>The special value <dfn>flag</dfn>, which indicates that the badge
-        is set, but contains no specific data.
-        </li>
-        <li>An {{unsigned long long}} value, which MUST NOT be 0.
-        </li>
-      </ul>
-      <p>
-        Each [=document=] and each [=installed web application=] is associated
-        with a <a>badge</a> value, which is initialized to <a>nothing</a>.
+        A <dfn>badge</dfn> is intended as a light-weight mechanism for
+        applications to subtly notify the user that there is some new activity
+        that might require their attention, or as a way of indicating a small
+        amount of information, such as an unread count.
       </p>
       <p>
-        The user agent MAY reset an application's badge to <a>nothing</a> at
-        its discretion (for example, when the system is restarted).
+        An [=installed web application=] has an associated [=badge=], which is
+        initialized to [="nothing"=].
       </p>
       <p>
-        If a <a>badge</a> is <a>nothing</a>, it is said to be
-        "<dfn data-local-lt="clearing">cleared</dfn>". Otherwise, it is said to
-        be "<dfn>set</dfn>".
+        A [=badge=] can have one of the following <dfn data-dfn-for=
+        "badge">values</dfn>:
       </p>
+      <dl>
+        <dt>
+          The special value <dfn>"nothing"</dfn>:
+        </dt>
+        <dd>
+          Indicates that there is no badge currently [=set=].
+        </dd>
+        <dt>
+          The special value <dfn>"flag"</dfn>:
+        </dt>
+        <dd>
+          Indicates that the badge is [=set=], but contains no specific value.
+        </dd>
+        <dt>
+          A <dfn>number</dfn> value:
+        </dt>
+        <dd>
+          Indicates that the badge is [=set=] to a numerical value greater than
+          `0`.
+        </dd>
+      </dl>
     </section>
-    <section>
+    <section id="presentation">
       <h2>
-        Badge display
+        Displaying a badge
       </h2>
       <p>
-        When a document's badge is <a>set</a>, if the document's [=browsing
-        context=] is a [=top-level browsing context=], the user agent SHOULD
-        display the document's badge value alongside the other identifying
-        information for that document (for example, on top of the document's
-        icon or near its title).
-      </p>
-      <p class="note">
-        The user agent is not expected to display a badge associated with a
-        document that is not a [=top-level browsing context=], although it is
-        allowed to. A user agent does not need to store the badge for a
-        non-top-level browsing context if it does not intend to display it.
+        When the application's badge is <dfn>set</dfn>, the user agent SHOULD
+        display the application's badge alongside any iconic representations of
+        the application in the user's operating system (for example, as a small
+        overlay on top of the application's icon).
       </p>
       <p>
-        When the application's badge is <a>set</a>, the user agent SHOULD
-        display the application's badge alongside any symbolic representations
-        of the application in the user's operating system (for example, as a
-        small overlay on top of the application's icon).
+        When the [=badge=] is [=set=] to [="flag"=], the user agent SHOULD show
+        an indicator with a non-specific symbol (such as a coloured circle).
       </p>
       <p>
-        If the badge is set to special value <a>flag</a>, the user agent SHOULD
-        show an indicator with a non-specific symbol (such as a coloured
-        circle).
+        When the [=badge=] is set to a [=number=], it SHOULD be formatted
+        according to the user's locale settings. For example, the badge content
+        '7' should be displayed as '7' in the locale 'en-NZ' (English as spoken
+        in New Zealand) but as '٧' in 'ar-EG' (Arabic as spoken in Egypt).
+        Furthermore, the user agent MAY simplify or degrade a badge's
+        [=number=] [=badge/value=] in any way. For example, a large number can
+        be saturated (for example, as "99+"). The font and formatting are
+        entirely at the user agent's or host operating system's discretion,
+        ideally to match user preferences. The user agent MAY ignore a badge's
+        [=badge/value=] and show a marker when the status is [=set=].
       </p>
       <p>
-        The user agent MAY simplify or degrade the data in any way. For
-        example, a large integer may be saturated (for example, as "99+"). The
-        font and formatting are entirely at the user agent's discretion. The
-        user agent MAY ignore the data, and merely show a marker when the
-        status is <a>set</a>.
-      </p>
-      <p>
-        When presenting a badge, it SHOULD be formatted according to the user's
-        <a data-cite="ltli/#locale">locale</a> settings. For example, the badge
-        content '7' should be displayed as '7' in the <a data-cite=
-        "ltli/#locale">locale</a> 'en-NZ' but as '٧' in 'ar-EG'.
+        When a [=badge=]'s value is [=set=] to [="nothing"=], it SHOULD be
+        <dfn data-local-lt="clearing|clear">cleared</dfn>: removing any
+        application badge that is currently being displayed.
       </p>
     </section>
-    <section>
+    <section data-dfn-for="NavigatorBadge">
       <h2>
         Extensions to the `Navigator` and `WorkerNavigator` interfaces
       </h2>
-      <p>
-        The {{Navigator}} and {{WorkerNavigator}} interfaces are extended with
-        methods for setting and [=clearing=] both the document and application
-        badge indicators from documents and service workers, respectively.
-      </p>
       <pre class="idl">
         [SecureContext]
-        partial interface Navigator {
-          Promise&lt;undefined&gt; setClientBadge(optional [EnforceRange] unsigned long long contents);
-          Promise&lt;undefined&gt; clearClientBadge();
-        };
-
-        [SecureContext]
         interface mixin NavigatorBadge {
-          Promise&lt;undefined&gt; setAppBadge(optional [EnforceRange] unsigned long long contents);
+          Promise&lt;undefined&gt; setAppBadge(
+            optional [EnforceRange] unsigned long long contents
+          );
           Promise&lt;undefined&gt; clearAppBadge();
         };
 
         Navigator includes NavigatorBadge;
         WorkerNavigator includes NavigatorBadge;
       </pre>
+      <h3>
+        <dfn>setAppBadge()</dfn> method
+      </h3>
       <p>
-        User agents that never display document badges SHOULD NOT expose the
-        {{Navigator/setClientBadge()}} and {{Navigator/clearClientBadge()}}
-        methods. Similarly, user agents that never display application badges
-        SHOULD NOT expose the {{NavigatorBadge/setAppBadge()}} and
-        {{NavigatorBadge/clearAppBadge()}} methods.
+        When the {{NavigatorBadge/setAppBadge()}} method is called, the user
+        agent MUST [=set the application badge=] of [=this=] to value of the
+        |contents:unsigned long long| argument.
       </p>
-      <p class="note">
-        This is important as a feature-detection mechanism to allow sites to
-        determine whether setting a badge will have any effect, based on the
-        presence of the methods. In particular, sites can use the absence of
-        {{Navigator/setClientBadge()}} as a condition for displaying a fallback
-        badge in the page's [^title^] or link type "icon".
+      <h3>
+        <dfn>clearAppBadge()</dfn> method
+      </h3>
+      <p>
+        When the {{NavigatorBadge/clearAppBadge()}} method is called, the user
+        agent MUST [=set the application badge=] of [=this=] to 0.
       </p>
-      <div class="issue" data-number="61"></div>
-      <section>
-        <h3>
-          <dfn data-dfn-for="Navigator">setClientBadge()</dfn> method
-        </h3>
-        <p>
-          When the {{Navigator/setClientBadge()}} method is called with
-          argument |contents:unsigned long long|:
-        </p>
-        <ol>
-          <li>Return [=a promise resolved with=] undefined, and [=in
-          parallel=]:
-            <ol>
-              <li>Let |document:Document| be [=this=]'s [=relevant global
-              object=]'s [=associated `Document`=].
-              </li>
-              <li>If |contents| is omitted, set the badge associated with
-              |document| to <a>flag</a>.
-              </li>
-              <li>Else, if |contents| is 0, set the badge associated with
-              |document| to <a>nothing</a>.
-              </li>
-              <li>Else, set the badge associated with |document| to |contents|.
-              </li>
-            </ol>
-          </li>
-        </ol>
-      </section>
-      <section>
-        <h3>
-          <dfn data-dfn-for="Navigator">clearClientBadge()</dfn> method
-        </h3>
-        <p>
-          When the {{Navigator/clearClientBadge()}} method is called:
-        </p>
-        <ol>
-          <li>Let |document:Document| be [=this=]'s [=relevant global object=]
-          [=associated document=].
-          </li>
-          <li>Return [=a promise resolved with=] undefined and [=In parallel=],
-          set the badge associated with |document| to <a>nothing</a>.
-          </li>
-        </ol>
-      </section>
-      <section>
-        <h3>
-          <dfn data-dfn-for="NavigatorBadge">setAppBadge()</dfn> method
-        </h3>
-        <p>
-          When the {{NavigatorBadge/setAppBadge()}} method is called with
-          argument |contents:unsigned long long|:
-        </p>
-        <ol>
-          <li>Let |global| be [=this=]'s [=relevant global object=].
-          </li>
-          <li>If |global|'s [=associated `Document`=] is null, and the
-          [=environment settings object=] is not a [=service worker client=],
-          return [=a promise rejected with=] a {{"NotSupportedError"}}
-          {{DOMException}}.
-          </li>
-          <li>Otherwise, return [=a promise resolved with=] undefined, and [=in
-          parallel=]:
-            <ol>
-              <li>Let |result:set of applications| be the result of
-              <a>determining the matching applications</a> on [=this=]'s
-              [=relevant settings object=].
-              </li>
-              <li>For each |app:application| in |result|:
-                <ol>
-                  <li>If |contents| is omitted, set the badge associated with
-                  |app| to <a>flag</a>.
-                  </li>
-                  <li>Else, if |contents| is 0, set the badge associated with
-                  |app| to <a>nothing</a>.
-                  </li>
-                  <li>Else, set the badge associated with |app| to |contents|.
-                  </li>
-                </ol>
-              </li>
-            </ol>
-          </li>
-        </ol>
-      </section>
-      <section>
-        <h3>
-          <dfn data-dfn-for="NavigatorBadge">clearAppBadge()</dfn> method
-        </h3>
-        <p>
-          When the {{NavigatorBadge/clearAppBadge()}} method is called:
-        </p>
-        <ol>
-          <li>Let |global| be [=this=]'s [=relevant global object=].
-          </li>
-          <li>If |global|'s [=associated `Document`=] is null, and the
-          [=environment settings object=] is not a [=service worker client=],
-          return [=a promise rejected with=] a {{"NotSupportedError"}}
-          {{DOMException}}.
-          </li>
-          <li>Otherwise, return [=a promise resolved with=] undefined, and [=in
-          parallel=]:
-            <ol>
-              <li>Let |result:set of applications| be the result of
-              <a>determining the matching applications</a> on [=this=]'s
-              [=relevant settings object=].
-              </li>
-              <li>Set the badge associated with each application in |result| to
-              <a>nothing</a>.
-              </li>
-            </ol>
-          </li>
-        </ol>
-      </section>
-      <section>
-        <h3>
-          Determining the set of matching applications
-        </h3>
-        <div class="note">
-          <p>
-            This algorithm is used to decide which app(s) receive a badge when
-            the {{NavigatorBadge/setAppBadge()}} method is called from either a
-            document or service worker context.
-          </p>
-          <p>
-            If called from a document context, the badge is applied to at most
-            one application: the one with the most specific scope whose scope
-            encloses this document URL.
-          </p>
-          <p>
-            If called from a service worker context, the badge is applied to
-            all applications whose scope sits within the service worker's
-            scope.
-          </p>
-        </div>
-        <p>
-          The steps for <dfn>determining the matching applications</dfn> takes
-          an [=environment settings object=] |environment:environment settings
-          object| that either has a [=global object=] with an [=associated
-          `Document`=], or is a [=service worker client=], and returns a
-          [=set=] of [=installed web applications=]:
-        </p>
-        <ol>
-          <li>If |environment| has a [=global object=] with an [=associated
-          `Document`=] that is not null:
-            <ol>
-              <li>Let |apps:set of applications| be the [=set=] of [=installed
-              web applications=] such that |document|'s {{Document/URL}} is
-              [=manifest/within scope=] of the application's manifest. (Order
-              is not important.)
-              </li>
-              <li>[=list/Remove=] all elements of |apps| other than the one
-              with the longest (i.e., most specific) [=manifest/navigation
-              scope=].
-              </li>
-              <li>Return |apps|.
-              </li>
-            </ol>
-          </li>
-          <li>Otherwise (|environment| is a [=service worker client=]):
-            <ol>
-              <li>Return the [=set=] of [=installed web applications=] whose
-              [=manifest/navigation scope=] is [=manifest/within scope=] of
-              |environment|'s [=service worker/containing service worker
-              registration=]'s [=service worker registration/scope url=].
-              (Order is not important.)
-              </li>
-            </ol>
-          </li>
-        </ol>
-      </section>
     </section>
-    <section class="informative">
+    <section>
+      <h2>
+        Setting the application badge
+      </h2>
+      <p>
+        To <dfn>set the application badge</dfn> of platform object [=this=] to
+        an optional {{unsigned long long}} |contents:unsigned long long| value:
+      </p>
+      <ol>
+        <li>Let |global| be [=this=]'s [=relevant global object=].
+        </li>
+        <li>If |global| is a {{Window}} object, then:
+          <ol>
+            <li>Let |document| be |global|'s [=associated `Document`=].
+            </li>
+            <li>If |document| is not [=Document/fully active=], return [=a
+            promise rejected with=] a {{InvalidStateError}}.
+            </li>
+          </ol>
+        </li>
+        <li>Let |environment| be |global|'s [=environment settings object=].
+        </li>
+        <li>Let |appId| be the |environment|'s [=environment settings
+        object/appId=].
+        </li>
+        <li>If |appId| is null, return [=a promise resolved with=] `undefined`.
+        </li>
+        <li>If the |environment|'s [=environment settings object/origin=] is
+        not [=same origin=] with with |appId|, return [=a promise rejected
+        with=] a {{SecurityError}}.
+        </li>
+        <li>Let |badge| be the [=badge=] associated with |appId|.
+        </li>
+        <li>Return [=a promise resolved with=] undefined, and [=in parallel=]:
+          <ol>
+            <li>Switching on |contents|, if it happens to be the case that:
+              <dl class="switch">
+                <dt>
+                  |contents| was not passed:
+                </dt>
+                <dd>
+                  [=Set=] |badge| to [="flag"=].
+                </dd>
+                <dt>
+                  |contents| is 0:
+                </dt>
+                <dd>
+                  [=Set=] the [=badge=] to [="nothing"=] and [=clear=] it.
+                </dd>
+                <dt>
+                  Default:
+                </dt>
+                <dd>
+                  [=Set=] |badge| to |contents|.
+                </dd>
+              </dl>
+            </li>
+          </ol>
+        </li>
+      </ol>
+    </section>
+    <section>
       <h2>
         Security and privacy considerations
       </h2>
@@ -403,7 +254,11 @@
         application badge cannot be used as a storage or fingerprinting
         mechanism.
       </p>
-      <div class="issue" data-number="44"></div>
+      <p>
+        The user agent MAY [=clear=] a [=badge=] at its discretion, and to
+        follow any system conventions (for example, when the system is reset).
+      </p>
+      <aside class="issue" data-number="68"></aside>
     </section>
     <section class="informative">
       <h2>

--- a/index.html
+++ b/index.html
@@ -16,22 +16,25 @@
         },
         group: "webapps",
         editors: [{
-          name: "Matt Giuca",
-          company: "Google Inc.",
-          companyURL: "https://google.com"
-        },
-        {
           name: "Marcos Cáceres",
           company: "Apple Inc.",
           companyURL: "https://apple.com",
-          w3cid: 78903
+          w3cid: 78903,
+        },
+        {
+          name: "Matt Giuca",
+          company: "Google Inc.",
+          companyURL: "https://google.com",
+          retiredDate: "2022-12-21",
         },
         {
           name: "Jay Harris",
+          company: "Google Inc.",
+          companyURL: "https://google.com",
           retiredDate: "2019-12-31"
         }],
         latestVersion: null,
-        // mdn: true, (not available yet)
+        mdn: true,
         xref: "web-platform",
       };
     </script>
@@ -39,15 +42,15 @@
   <body data-cite="appmanifest">
     <section id="abstract">
       <p>
-        This specification defines an API allowing [=installed web
-        applications=] to set an application badge, which is usually shown in
-        an operating-system-specific place associated with the application
-        (such as the shelf, dock, or home screen).
+        This specification defines an API that allows [=installed web
+        applications=] to set an application badge, which is usually shown
+        alongside the application's icon on the device's home screen or
+        application dock.
       </p>
     </section>
     <section id="sotd">
       <p>
-        This is an early draft of the Badging API spec.
+        This is a work in progress.
       </p>
     </section>
     <section class="informative">
@@ -56,42 +59,72 @@
       </h2>
       <pre class="example javascript" title=
       "Showing unread count on the app icon">
-        function pollForMail() {
-          // ... Fetch unread mail from server. ...
+        async function updateMailBadge() {
+          // Check if the API is supported.
+          if (!navigator.setAppBadge) return;
 
-          // Set the app badge.
-          navigator.setAppBadge(getUnreadCount());
+          const unreadCount = await getUnreadMailCount();
+
+          // Try to set the app badge.
+          try {
+            await navigator.setAppBadge(unreadCount);
+          } catch (e) {
+            // The badge is not supported, or the user has prevented the app
+            // from setting a badge.
+          }
         }
       </pre>
       <p>
         The badge might show up on the application's icon in the operating
-        system. If multiple API calls within the same application [=set=] or
-        [=clear=] a badge, the most recent one takes effect, and may continue
-        being seen even after an application is closed.
+        system. If multiple API calls within the same application [=badge/set=]
+        or [=badge/clear=] a badge, the most recent one takes effect, and may
+        continue being seen even after an application is closed.
       </p>
       <pre class="example javascript" title=
       "Showing ready status on the app icon">
-        function showPlayerTurn(playerTurnId) {
+        async function showPlayerTurn(playerTurnId) {
           if (playerTurnId === localPlayerId)
-            navigator.setAppBadge();
+            await navigator.setAppBadge();
           else
-            navigator.clearAppBadge();
+            await navigator.clearAppBadge();
+        }
+      </pre>
+      <p data-cite="notifications">
+        On some operating systems [=badge/setting=] a badge can require
+        permission from the user. In this case, a developer need to query the
+        "[=notifications=]" permissions status before [=badge/setting=] a
+        badge. If the permission is not granted, the developer will need to
+        prompt for permission via the
+        {{Notification}}.{{Notification/requestPermission()}}.
+      </p>
+      <pre class="example javascript" title="Checking for permission">
+        async function checkPermission() {
+          permission = await navigator.permissions.query({
+            name: "notifications",
+          });
+          const button = document.getElementById("permission-button");
+          if (permission.state === "prompt") {
+            // Prompt the user to grant permission.
+            button.hidden = false;
+            button.addEventListener("click", async () =&gt; {
+              await Notification.requestPermission();
+              checkPermission();
+            }, { once: true });
+            return;
+          }
+          button.hidden = true;
         }
       </pre>
     </section>
     <section>
       <h2>
-        Badge model
+        Model
       </h2>
       <p>
-        A <dfn>badge</dfn> is intended as a light-weight mechanism for
-        applications to subtly notify the user that there is some new activity
-        that might require their attention, or as a way of indicating a small
-        amount of information, such as an unread count.
-      </p>
-      <p>
-        An [=installed web application=] has an associated [=badge=], which is
-        initialized to [="nothing"=].
+        A <dfn>badge</dfn> is intended as a mechanism for [=installed web
+        applications=] to notify the user that there is some new activity that
+        might require their attention, or as a way of indicating a small amount
+        of information, such as an unread count.
       </p>
       <p>
         A [=badge=] can have one of the following <dfn data-dfn-for=
@@ -102,54 +135,84 @@
           The special value <dfn>"nothing"</dfn>:
         </dt>
         <dd>
-          Indicates that there is no badge currently [=set=].
+          Indicates that there is no badge currently [=badge/set=].
         </dd>
         <dt>
           The special value <dfn>"flag"</dfn>:
         </dt>
         <dd>
-          Indicates that the badge is [=set=], but contains no specific value.
+          Indicates that the badge is [=badge/set=], but contains no specific
+          value.
         </dd>
         <dt>
           A <dfn>number</dfn> value:
         </dt>
         <dd>
-          Indicates that the badge is [=set=] to a numerical value greater than
-          `0`.
+          Indicates that the badge is [=badge/set=] to a numerical value
+          greater than `0`.
         </dd>
       </dl>
+      <p>
+        An [=installed web application=] has an associated [=badge=], which is
+        initialized to [="nothing"=].
+      </p>
+      <p>
+        The user agent MAY (re)[=set=] an application's badge to [="nothing"=]
+        at its discretion (for example, following system conventions).
+      </p>
     </section>
     <section id="presentation">
       <h2>
         Displaying a badge
       </h2>
       <p>
-        When the application's badge is <dfn>set</dfn>, the user agent SHOULD
-        display the application's badge alongside any iconic representations of
-        the application in the user's operating system (for example, as a small
-        overlay on top of the application's icon).
+        When the application's badge is <dfn data-dfn-for="badge" data-lt=
+        "setting">set</dfn>, the [=user agent=] or operating system SHOULD
+        display the application's [=badge=] alongside the primary iconic
+        representation of the application in the user's operating system (for
+        example, as a small overlay on top of the application's icon on the
+        home screen on a device).
+      </p>
+      <p data-cite="permissions notifications">
+        A user agent MAY require [=express permission=] from the user to
+        [=badge/set=] the badge. When a user agent requires such
+        [=permission=], it SHOULD tie the permission grant to the
+        "[=notifications=]" permission.
       </p>
       <p>
-        When the [=badge=] is [=set=] to [="flag"=], the user agent SHOULD show
-        an indicator with a non-specific symbol (such as a coloured circle).
+        When the [=badge=] is [=badge/set=] to [="flag"=], the [=user agent=]
+        or operating system SHOULD display an indicator with a non-specific
+        symbol (for example, a colored circle).
       </p>
       <p>
-        When the [=badge=] is set to a [=number=], it SHOULD be formatted
-        according to the user's locale settings. For example, the badge content
-        '7' should be displayed as '7' in the locale 'en-NZ' (English as spoken
-        in New Zealand) but as '٧' in 'ar-EG' (Arabic as spoken in Egypt).
-        Furthermore, the user agent MAY simplify or degrade a badge's
-        [=number=] [=badge/value=] in any way. For example, a large number can
-        be saturated (for example, as "99+"). The font and formatting are
-        entirely at the user agent's or host operating system's discretion,
-        ideally to match user preferences. The user agent MAY ignore a badge's
-        [=badge/value=] and show a marker when the status is [=set=].
+        When a [=badge=]'s value is [=badge/set=] to [="nothing"=], the [=user
+        agent=] or operating system SHOULD <dfn data-dfn-for="badge"
+        data-local-lt="clearing|cleared">clear</dfn> the [=badge=] by no longer
+        displaying it.
       </p>
       <p>
-        When a [=badge=]'s value is [=set=] to [="nothing"=], it SHOULD be
-        <dfn data-local-lt="clearing|clear">cleared</dfn>: removing any
-        application badge that is currently being displayed.
+        When the [=badge=] is [=badge/set=] to a [=number=], the [=user agent=]
+        or operating system:
       </p>
+      <ul>
+        <li>SHOULD format and display the number according to the user's font
+        and formatting preferences. For example, as a number in a circle on top
+        of the application's icon on the home screen on a device.
+        </li>
+        <li>MAY simplify or degrade a badge's [=number=] [=badge/value=] in any
+        way that matches the platform's conventions for representing numbers in
+        a badge. For example, a platform might choose to display a badge with a
+        value of '100' as '99+'.
+        </li>
+        <li>SHOULD localize the number according to the user's locale
+        preferences. For example, the [=badge/value=] '7' should be displayed
+        as '7' in the locale 'en' (English) but as '٧' in 'ar' (Arabic).
+        </li>
+        <li>MAY treat a [=number=] [=badge/value=] as [="flag"=], or whatever
+        representation is most appropriate for the platform, if the platform
+        does not support displaying [=numbers=] in a [=badge=].
+        </li>
+      </ul>
     </section>
     <section data-dfn-for="NavigatorBadge">
       <h2>
@@ -167,6 +230,10 @@
         Navigator includes NavigatorBadge;
         WorkerNavigator includes NavigatorBadge;
       </pre>
+      <p>
+        User agents that never display application badges SHOULD NOT
+        [=interface/include=] {{NavigatorBadge}}.
+      </p>
       <h3>
         <dfn>setAppBadge()</dfn> method
       </h3>
@@ -183,16 +250,17 @@
         agent MUST [=set the application badge=] of [=this=] to 0.
       </p>
     </section>
-    <section>
+    <section data-cite="permissions notifications">
       <h2>
         Setting the application badge
       </h2>
       <p>
-        To <dfn>set the application badge</dfn> of platform object [=this=] to
-        an optional {{unsigned long long}} |contents:unsigned long long| value:
+        To <dfn>set the application badge</dfn> of platform object
+        |context:platform object| to an optional {{unsigned long long}}
+        |contents:unsigned long long| value:
       </p>
-      <ol>
-        <li>Let |global| be [=this=]'s [=relevant global object=].
+      <ol class="algorithm">
+        <li>Let |global| be |context|'s [=relevant global object=].
         </li>
         <li>If |global| is a {{Window}} object, then:
           <ol>
@@ -203,44 +271,57 @@
             </li>
           </ol>
         </li>
-        <li>Let |environment| be |global|'s [=environment settings object=].
+        <li>Let |promise| be [=a new promise=].
         </li>
-        <li>Let |appId| be the |environment|'s [=environment settings
-        object/appId=].
-        </li>
-        <li>If |appId| is null, return [=a promise resolved with=] `undefined`.
-        </li>
-        <li>If the |environment|'s [=environment settings object/origin=] is
-        not [=same origin=] with with |appId|, return [=a promise rejected
-        with=] a {{SecurityError}}.
-        </li>
-        <li>Let |badge| be the [=badge=] associated with |appId|.
-        </li>
-        <li>Return [=a promise resolved with=] undefined, and [=in parallel=]:
+        <li>[=In parallel=]:
           <ol>
+            <li>If [=this=]'s [=relevant settings object=]'s [=origin=] is not
+            [=same origin=] with [=this=]'s [=relevant settings object=]'s
+            [=environment/top-level origin=], [=queue a global task=] on the
+            [=DOM manipulation task source=] given |global| to [=reject=]
+            |promise| with a {{"SecurityError"}} and terminate this algorithm.
+            </li>
+            <li>If the [=user agent=] requires [=express permission=] to
+            [=badge/set=] the application badge, then:
+              <ol>
+                <li>Let |permissionState| be the result of [=getting the
+                current permission state=] with "[=notifications=]".
+                </li>
+                <li>If |permissionState| is not {{PermissionState/"granted"}},
+                [=queue a global task=] on the [=user interaction task source=]
+                given |global| to [=reject=] |promise| with a
+                {{NotAllowedError}} and terminate this algorithm.
+                </li>
+              </ol>
+            </li>
             <li>Switching on |contents|, if it happens to be the case that:
               <dl class="switch">
                 <dt>
                   |contents| was not passed:
                 </dt>
                 <dd>
-                  [=Set=] |badge| to [="flag"=].
+                  [=badge/Set=] |badge| to [="flag"=].
                 </dd>
                 <dt>
                   |contents| is 0:
                 </dt>
                 <dd>
-                  [=Set=] the [=badge=] to [="nothing"=] and [=clear=] it.
+                  [=badge/Set=] |badge| to [="nothing"=].
                 </dd>
                 <dt>
-                  Default:
+                  |contents|:
                 </dt>
                 <dd>
-                  [=Set=] |badge| to |contents|.
+                  [=badge/Set=] |badge| to |contents|.
                 </dd>
               </dl>
             </li>
+            <li>[=Queue a global task=] on the [=DOM manipulation task source=]
+            given |global| to [=resolve=] |promise| with `undefined`.
+            </li>
           </ol>
+        </li>
+        <li>Return |promise|.
         </li>
       </ol>
     </section>
@@ -255,8 +336,9 @@
         mechanism.
       </p>
       <p>
-        The user agent MAY [=clear=] a [=badge=] at its discretion, and to
-        follow any system conventions (for example, when the system is reset).
+        The [=user agent=] or operating system MAY [=badge/clear=] a [=badge=]
+        at its discretion, and to follow any system conventions (for example,
+        when the system is reset).
       </p>
       <aside class="issue" data-number="68"></aside>
     </section>


### PR DESCRIPTION
This PR... 

* Drops `setClientBadge()` and `clearClientBadge()` due to limited implementer interest.
* Removes dependency on Service Worker - the API is available in any “worker” context.
* For `Window` context, added document is fully active check.
* Matches Chrome’s behavior or exposing the API to the Web, but making it a no-op when an app is not installed.
* Add fully active check for document in `Window` context. 
* Leaves actual display on badging to the end-user.  

closes #95 
closes #94 
closes #93 
closes #92
closes #66
closes #44


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/badging/pull/98.html" title="Last updated on Mar 24, 2023, 6:20 AM UTC (0a2bce3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/badging/98/23b5620...0a2bce3.html" title="Last updated on Mar 24, 2023, 6:20 AM UTC (0a2bce3)">Diff</a>