### PR TITLE
synchronously use same origin-domain in iframe check

### DIFF
--- a/index.html
+++ b/index.html
@@ -279,18 +279,17 @@
             <li>If |document| is not [=Document/fully active=], return [=a
             promise rejected with=] a {{InvalidStateError}}.
             </li>
+            <li>If |document|'s [=relevant settings object=]'s [=origin=] is not
+            [=same origin-domain=] with [=this=]'s [=relevant settings object=]'s
+            [=environment/top-level origin=], return [=a promise rejected
+            with=] a {{"SecurityError"}} {{DOMException}}.
+            </li>
           </ol>
         </li>
         <li>Let |promise| be [=a new promise=].
         </li>
         <li>[=In parallel=]:
           <ol>
-            <li>If [=this=]'s [=relevant settings object=]'s [=origin=] is not
-            [=same origin=] with [=this=]'s [=relevant settings object=]'s
-            [=environment/top-level origin=], [=queue a global task=] on the
-            [=DOM manipulation task source=] given |global| to [=reject=]
-            |promise| with a {{"SecurityError"}} and terminate this algorithm.
-            </li>
             <li>If the [=user agent=] requires [=express permission=] to
             [=badge/set=] the application badge, then:
               <ol>


### PR DESCRIPTION
Closes #106 

Now checks "same origin-domain" instead of the more restrictive "same origin". 

This change:

* Adds new normative requirements

Implementation commitment (delete if not making normative changes):

* [ ] Modified Web platform tests (link)
* [ ] WebKit (https://bugs.webkit.org)
* [ ] Chromium (https://bugs.chromium.org/)
* [ ] Gecko (http://bugzilla.mozilla.org)

Person merging, please make sure that commits are squashed with one of the following as a commit message prefix:

* chore:
* editorial:
* BREAKING CHANGE:
* And use none if it's a normative change
