### PR TITLE
BREAKING CHANGE: remove permissions check

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -155,9 +155,12 @@ state changes that would be convenient for the user to be able to see at a
 glance, but not important enough to disrupt the user, use of the Badge API
 without a notification is warranted.
 
-There may be no need to request permission to use the badging API, since it is
-much less invasive than a notification, but this is at the discretion of the
-user agent.
+There is no need to request permission to use the badging API. The badge can
+always be set successfully by the application, though the operating system
+ultimately controls whether it is displayed to the user. On some platforms,
+calling `Notification.requestPermission()` may be necessary for the badge to
+become visible to the user, even though the badge itself has been successfully
+set by the application.
 
 ## Usage examples
 

--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
       <p data-cite="notifications">
         On some operating systems, the actual display of a [=badge=] to the user
         may depend on notification permissions, even though [=badge/setting=] a
-        badge will always succeed. Developers can optionally check the
+        badge will always succeed (even if the badge value is not displayed to the user). Developers can optionally check the
         "[=notifications=]" permission status and prompt for permission to help
         ensure badge visibility on platforms where this is relevant.
       </p>
@@ -191,9 +191,9 @@
         The operating system ultimately controls whether a [=badge=] is displayed
         to the user, typically through system-level application settings. On some
         platforms, calling {{Notification}}.{{Notification/requestPermission()}}
-        may be necessary for a [=badge=] to become visible to the user, even though
-        the badge itself can be successfully [=badge/set=] by the application.
-        The [=user agent=] SHOULD allow applications to [=badge/set=] badges
+        can be necessary for a [=badge=] to become visible to the user, even though
+        the badge itself can be successfully [=badge/set=] by the [=installed web application|application=].
+        The [=user agent=] SHOULD allow [=installed web application|applications=] to [=badge/set=] badges
         regardless of permission state, with the understanding that the operating
         system will control the actual display behavior.
       </p>

--- a/index.html
+++ b/index.html
@@ -101,13 +101,16 @@
         }
       </pre>
       <p data-cite="notifications">
-        On some operating systems, the actual display of a [=badge=] to the user
-        may depend on notification permissions, even though [=badge/setting=] a
-        badge will always succeed (even if the badge value is not displayed to the user). Developers can optionally check the
+        On some operating systems, the actual display of a [=badge=] to the
+        user may depend on notification permissions, even though
+        [=badge/setting=] a badge will always succeed (even if the badge value
+        is not displayed to the user). Developers can optionally check the
         "[=notifications=]" permission status and prompt for permission to help
         ensure badge visibility on platforms where this is relevant.
       </p>
-      <pre class="example javascript" title="Optionally checking for notification permission to ensure badge visibility">
+      <pre class="example javascript" title=
+      "Optionally checking for notification permission to ensure badge visibility">
+
         async function checkNotificationPermissionForBadge() {
           // Always set the badge first - this will succeed regardless of permissions
           await navigator.setAppBadge(5);
@@ -188,14 +191,16 @@
         home screen on a device).
       </p>
       <p data-cite="permissions notifications">
-        The operating system ultimately controls whether a [=badge=] is displayed
-        to the user, typically through system-level application settings. On some
-        platforms, calling {{Notification}}.{{Notification/requestPermission()}}
-        can be necessary for a [=badge=] to become visible to the user, even though
-        the badge itself can be successfully [=badge/set=] by the [=installed web application|application=].
-        The [=user agent=] SHOULD allow [=installed web application|applications=] to [=badge/set=] badges
-        regardless of permission state, with the understanding that the operating
-        system will control the actual display behavior.
+        The operating system ultimately controls whether a [=badge=] is
+        displayed to the user, typically through system-level application
+        settings. On some platforms, calling
+        {{Notification}}.{{Notification/requestPermission()}} can be necessary
+        for a [=badge=] to become visible to the user, even though the badge
+        itself can be successfully [=badge/set=] by the [=installed web
+        application|application=]. The [=user agent=] SHOULD allow [=installed
+        web application|applications=] to [=badge/set=] badges regardless of
+        permission state, with the understanding that the operating system will
+        control the actual display behavior.
       </p>
       <p>
         When the [=badge=] is [=badge/set=] to [="flag"=], the [=user agent=]

--- a/index.html
+++ b/index.html
@@ -75,12 +75,13 @@
 
           const unreadCount = await getUnreadMailCount();
 
-          // Try to set the app badge.
+          // Set the app badge - this will always succeed if the API is supported.
+          // The operating system controls whether the badge is actually displayed.
           try {
             await navigator.setAppBadge(unreadCount);
           } catch (e) {
-            // The badge is not supported, or the user has prevented the app
-            // from setting a badge.
+            // Errors are rare and typically indicate API unavailability
+            // or security restrictions, not permission issues.
           }
         }
       </pre>
@@ -100,25 +101,28 @@
         }
       </pre>
       <p data-cite="notifications">
-        On some operating systems [=badge/setting=] a badge can require
-        permission from the user. In this case, a developer need to query the
-        "[=notifications=]" permissions status before [=badge/setting=] a
-        badge. If the permission is not granted, the developer will need to
-        prompt for permission via the
-        {{Notification}}.{{Notification/requestPermission()}}.
+        On some operating systems, the actual display of a [=badge=] to the user
+        may depend on notification permissions, even though [=badge/setting=] a
+        badge will always succeed. Developers can optionally check the
+        "[=notifications=]" permission status and prompt for permission to help
+        ensure badge visibility on platforms where this is relevant.
       </p>
-      <pre class="example javascript" title="Checking for permission">
-        async function checkPermission() {
-          permission = await navigator.permissions.query({
+      <pre class="example javascript" title="Optionally checking for notification permission to ensure badge visibility">
+        async function checkNotificationPermissionForBadge() {
+          // Always set the badge first - this will succeed regardless of permissions
+          await navigator.setAppBadge(5);
+          
+          // Check if notification permission might affect badge visibility
+          const permission = await navigator.permissions.query({
             name: "notifications",
           });
           const button = document.getElementById("permission-button");
           if (permission.state === "prompt") {
-            // Prompt the user to grant permission.
+            // Show option to grant permission for badge visibility
             button.hidden = false;
             button.addEventListener("click", async () =&gt; {
               await Notification.requestPermission();
-              checkPermission();
+              checkNotificationPermissionForBadge();
             }, { once: true });
             return;
           }
@@ -184,10 +188,14 @@
         home screen on a device).
       </p>
       <p data-cite="permissions notifications">
-        A user agent MAY require [=express permission=] from the user to
-        [=badge/set=] the badge. When a user agent requires such
-        [=permission=], it SHOULD tie the permission grant to the
-        "[=notifications=]" permission.
+        The operating system ultimately controls whether a [=badge=] is displayed
+        to the user, typically through system-level application settings. On some
+        platforms, calling {{Notification}}.{{Notification/requestPermission()}}
+        may be necessary for a [=badge=] to become visible to the user, even though
+        the badge itself can be successfully [=badge/set=] by the application.
+        The [=user agent=] SHOULD allow applications to [=badge/set=] badges
+        regardless of permission state, with the understanding that the operating
+        system will control the actual display behavior.
       </p>
       <p>
         When the [=badge=] is [=badge/set=] to [="flag"=], the [=user agent=]
@@ -290,19 +298,6 @@
         </li>
         <li>[=In parallel=]:
           <ol>
-            <li>If the [=user agent=] requires [=express permission=] to
-            [=badge/set=] the application badge, then:
-              <ol>
-                <li>Let |permissionState| be the result of [=getting the
-                current permission state=] with "[=notifications=]".
-                </li>
-                <li>If |permissionState| is not {{PermissionState/"granted"}},
-                [=queue a global task=] on the [=user interaction task source=]
-                given |global| to [=reject=] |promise| with a
-                {{NotAllowedError}} and terminate this algorithm.
-                </li>
-              </ol>
-            </li>
             <li>Switching on |contents|, if it happens to be the case that:
               <dl class="switch">
                 <dt>


### PR DESCRIPTION
Closes #110 

This pull request clarifies how the Badging API interacts with permissions and system-level controls, both in the documentation (`explainer.md`) and in the example code and explanatory text (`index.html`). The main focus is to make it clear that setting a badge does not require explicit permission, but actual badge visibility may depend on notification permissions on some platforms. The changes also update the example code and specification language to reflect this behavior.

**Clarifications to Badging API Permission Behavior:**

* Updated `explainer.md` to state that applications do not need to request permission to set a badge, but actual display may depend on notification permissions on some platforms.
* Revised explanatory text in `index.html` to clarify that setting a badge always succeeds if the API is supported, but the operating system controls whether the badge is displayed. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L78-R84) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L103-R125)
* Updated the specification language in `index.html` to remove the requirement for explicit user permission to set a badge, instead explaining that the operating system determines badge visibility and that the user agent should allow setting badges regardless of permission state. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L187-R198) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L293-L305)

**Example Code Improvements:**

* Enhanced the example code in `index.html` to demonstrate that badges can be set regardless of notification permissions, and added an optional check for notification permission to help ensure badge visibility on relevant platforms.

This change (choose at least one, delete ones that don't apply):

* Breaks existing normative behavior (please add label "breaking")
* Adds new normative requirements

Implementation commitment (delete if not making normative changes):

* [ ] Modified Web platform tests (link)
* [X] WebKit - behavior reflects Safari installed web applications on iOS and macOS 26.  
* [ ] Chromium 
* [ ] Gecko (http://bugzilla.mozilla.org)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/badging/pull/121.html" title="Last updated on Sep 9, 2025, 12:40 AM UTC (61976a1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/badging/121/3a87869...61976a1.html" title="Last updated on Sep 9, 2025, 12:40 AM UTC (61976a1)">Diff</a>