### PR TITLE
Editorial: clarify OS is backing store

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,9 +184,9 @@
       </dl>
       <p>
         An [=installed web application=] has an associated [=badge=], which is
-        initialized to [="nothing"=]. The operating system stores and manages
-        the badge value, with the [=user agent=] acting as an intermediary to
-        communicate badge changes to the OS.
+        initialized to [=badge/"nothing"=]. The operating system stores and
+        manages the badge value, with the [=user agent=] acting as an
+        intermediary to communicate badge changes to the OS.
       </p>
       <p>
         The user agent MAY (re)[=set=] an application's badge to

--- a/index.html
+++ b/index.html
@@ -184,9 +184,9 @@
       </dl>
       <p>
         An [=installed web application=] has an associated [=badge=], which is
-        initialized to [="nothing"=]. The operating system typically serves as
-        the backing store for the badge value, with the [=user agent=] acting
-        as an intermediary to communicate badge changes to the OS.
+        initialized to [="nothing"=]. The operating system stores and manages
+        the badge value, with the [=user agent=] acting as an intermediary to
+        communicate badge changes to the OS.
       </p>
       <p>
         The user agent MAY (re)[=set=] an application's badge to

--- a/index.html
+++ b/index.html
@@ -184,7 +184,9 @@
       </dl>
       <p>
         An [=installed web application=] has an associated [=badge=], which is
-        initialized to [=badge/"nothing"=].
+        initialized to [="nothing"=]. The operating system typically serves as
+        the backing store for the badge value, with the [=user agent=] acting
+        as an intermediary to communicate badge changes to the OS.
       </p>
       <p>
         The user agent MAY (re)[=set=] an application's badge to


### PR DESCRIPTION
Closes #113 

This pull request clarifies how badge values are managed for installed web applications in the `index.html` documentation. Specifically, it explains that the operating system is responsible for storing and managing the badge value, with the user agent serving as an intermediary to communicate changes.

Documentation clarification:

* Updated the description of badge initialization to state that the operating system manages the badge value and the user agent communicates badge changes to the OS.

This change:

* Makes editorial changes (changes informative sections, or changes normative sections without changing behavior)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/badging/pull/122.html" title="Last updated on Sep 9, 2025, 12:54 AM UTC (721405e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/badging/122/3a87869...721405e.html" title="Last updated on Sep 9, 2025, 12:54 AM UTC (721405e)">Diff</a>