### PR TITLE
More gracefully handle badging limitations

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -493,7 +493,7 @@ App badges are shown in OS-specific contexts. User agents should attempt reuse e
 
 Different operating systems have varying support for badge types. Since the OS ultimately controls badge rendering, user agents must communicate the correct semantic intent:
 
-* **Flag support**: Some platforms do not natively support "flag" badges (badges without numbers). In such cases, user agents should communicate to the OS using the closest available representation that conveys badge presence (such as a generic symbol or minimal number) rather than requesting badge clearing.
+* **Flag support**: Some platforms do not natively support "flag" badges (badges without numbers). In such cases, user agents should communicate to the OS using the closest available representation that conveys badge presence (such as a generic symbol or the number "1") rather than requesting badge clearing.
 * **Number support**: Some platforms may not support numbered badges. In such cases, user agents may communicate the badge to the OS as a flag representation.
 * **Semantic preservation**: User agents must preserve the semantic distinction between "flag" (show something) and "nothing" (show nothing) when communicating with the operating system, even when platform capabilities are limited.
 * **OS control**: The ultimate display behavior is controlled by the operating system and may be further modified by user settings or system conventions.

--- a/explainer.md
+++ b/explainer.md
@@ -495,7 +495,7 @@ Different operating systems have varying support for badge types. Since the OS u
 
 * **Flag support**: Some platforms do not natively support "flag" badges (badges without numbers). In such cases, user agents communicate to the OS using the closest available representation that conveys badge presence (such as a generic symbol or the number "1") rather than requesting badge clearing.
 * **Number support**: Some platforms may not support numbered badges. In such cases, user agents may communicate the badge to the OS as a flag representation.
-* **Semantic preservation**: User agents must preserve the semantic distinction between "flag" (show something) and "nothing" (show nothing) when communicating with the operating system, even when platform capabilities are limited.
+* **Semantic preservation**: User agents preserve the semantic distinction between "flag" (show something) and "nothing" (show nothing) when communicating with the operating system, even when platform capabilities are limited.
 * **OS control**: The ultimate display behavior is controlled by the operating system and may be further modified by user settings or system conventions.
 
 This approach ensures consistent semantic behavior across platforms and prevents the issues identified in implementations where `setAppBadge()` (flag) incorrectly clears badges instead of displaying them.

--- a/explainer.md
+++ b/explainer.md
@@ -494,7 +494,7 @@ App badges are shown in OS-specific contexts. User agents should attempt reuse e
 Different operating systems have varying support for badge types. Since the OS ultimately controls badge rendering, it is the user agent that communicate the correct semantic intent:
 
 * **Flag support**: Some platforms do not natively support "flag" badges (badges without numbers). In such cases, user agents communicate to the OS using the closest available representation that conveys badge presence (such as a generic symbol or the number "1") rather than requesting badge clearing.
-* **Number support**: Some platforms may not support numbered badges. In such cases, user agents may communicate the badge to the OS as a flag representation.
+* **Number support**: Some platforms might not support numbered badges. In such cases, user agents can communicate the badge to the OS as a flag representation.
 * **Semantic preservation**: User agents preserve the semantic distinction between "flag" (show something) and "nothing" (show nothing) when communicating with the operating system, even when platform capabilities are limited.
 * **OS control**: The ultimate display behavior is controlled by the operating system and may be further modified by user settings or system conventions.
 

--- a/explainer.md
+++ b/explainer.md
@@ -496,7 +496,7 @@ Different operating systems have varying support for badge types. Since the OS u
 * **Flag support**: Some platforms do not natively support "flag" badges (badges without numbers). In such cases, user agents communicate to the OS using the closest available representation that conveys badge presence (such as a generic symbol or the number "1") rather than requesting badge clearing.
 * **Number support**: Some platforms might not support numbered badges. In such cases, user agents can communicate the badge to the OS as a flag representation.
 * **Semantic preservation**: User agents preserve the semantic distinction between "flag" (show something) and "nothing" (show nothing) when communicating with the operating system, even when platform capabilities are limited.
-* **OS control**: The ultimate display behavior is controlled by the operating system and may be further modified by user settings or system conventions.
+* **OS control**: The ultimate display behavior is controlled by the operating system and can be further controlled by user settings or system conventions.
 
 This approach ensures consistent semantic behavior across platforms and prevents the issues identified in implementations where `setAppBadge()` (flag) incorrectly clears badges instead of displaying them.
 

--- a/explainer.md
+++ b/explainer.md
@@ -493,7 +493,7 @@ App badges are shown in OS-specific contexts. User agents should attempt reuse e
 
 Different operating systems have varying support for badge types. Since the OS ultimately controls badge rendering, it is the user agent that communicate the correct semantic intent:
 
-* **Flag support**: Some platforms do not natively support "flag" badges (badges without numbers). In such cases, user agents should communicate to the OS using the closest available representation that conveys badge presence (such as a generic symbol or the number "1") rather than requesting badge clearing.
+* **Flag support**: Some platforms do not natively support "flag" badges (badges without numbers). In such cases, user agents communicate to the OS using the closest available representation that conveys badge presence (such as a generic symbol or the number "1") rather than requesting badge clearing.
 * **Number support**: Some platforms may not support numbered badges. In such cases, user agents may communicate the badge to the OS as a flag representation.
 * **Semantic preservation**: User agents must preserve the semantic distinction between "flag" (show something) and "nothing" (show nothing) when communicating with the operating system, even when platform capabilities are limited.
 * **OS control**: The ultimate display behavior is controlled by the operating system and may be further modified by user settings or system conventions.

--- a/explainer.md
+++ b/explainer.md
@@ -491,7 +491,7 @@ App badges are shown in OS-specific contexts. User agents should attempt reuse e
 
 ### Implementation Considerations for Platform Limitations
 
-Different operating systems have varying support for badge types. Since the OS ultimately controls badge rendering, user agents must communicate the correct semantic intent:
+Different operating systems have varying support for badge types. Since the OS ultimately controls badge rendering, it is the user agent that communicate the correct semantic intent:
 
 * **Flag support**: Some platforms do not natively support "flag" badges (badges without numbers). In such cases, user agents should communicate to the OS using the closest available representation that conveys badge presence (such as a generic symbol or the number "1") rather than requesting badge clearing.
 * **Number support**: Some platforms may not support numbered badges. In such cases, user agents may communicate the badge to the OS as a flag representation.

--- a/explainer.md
+++ b/explainer.md
@@ -443,6 +443,8 @@ At any time, the badge for a specific document or app, if it is set, may be eith
 
 The model does not allow a badge to be a negative integer, or the integer value 0 (setting the badge to 0 is equivalent to clearing the badge).
 
+**Important distinction**: A "flag" badge should display a visual indicator to the user (such as a dot or circle), whereas a cleared badge (value 0 or calling `clearAppBadge()`) should display nothing. These are semantically different states, and platforms must not treat a request to set a "flag" as equivalent to clearing the badge.
+
 The user agent is allowed to clear all badges on an origin whenever there are no foreground pages open on the origin (the intention of this is so that when the user agent quits, it does not need to serialize all the badge data and restore it on start-up; sites should re-apply the badge when they open).
 
 ### The API
@@ -486,6 +488,17 @@ Appropriate places for a document badge could include:
 - OS-specific contexts for app window icons if the document is open in a [standalone window](https://www.w3.org/TR/appmanifest/#display-modes).
 
 App badges are shown in OS-specific contexts. User agents should attempt reuse existing [operating system APIs and conventions](docs/implementation.md), to achieve a native look-and-feel for the badge.
+
+### Implementation Considerations for Platform Limitations
+
+Different operating systems have varying support for badge types. Since the OS ultimately controls badge rendering, user agents must communicate the correct semantic intent:
+
+* **Flag support**: Some platforms do not natively support "flag" badges (badges without numbers). In such cases, user agents should communicate to the OS using the closest available representation that conveys badge presence (such as a generic symbol or minimal number) rather than requesting badge clearing.
+* **Number support**: Some platforms may not support numbered badges. In such cases, user agents may communicate the badge to the OS as a flag representation.
+* **Semantic preservation**: User agents must preserve the semantic distinction between "flag" (show something) and "nothing" (show nothing) when communicating with the operating system, even when platform capabilities are limited.
+* **OS control**: The ultimate display behavior is controlled by the operating system and may be further modified by user settings or system conventions.
+
+This approach ensures consistent semantic behavior across platforms and prevents the issues identified in implementations where `setAppBadge()` (flag) incorrectly clears badges instead of displaying them.
 
 ## Security and Privacy Considerations
 The API is write-only, so data badged can't be used to track a user. Whether the API is present could possibly be used as a bit of entropy to fingerprint users, but this is the case for all new APIs.

--- a/explainer.md
+++ b/explainer.md
@@ -491,7 +491,7 @@ App badges are shown in OS-specific contexts. User agents should attempt reuse e
 
 ### Implementation Considerations for Platform Limitations
 
-Different operating systems have varying support for badge types. Since the OS ultimately controls badge rendering, it is the user agent that communicate the correct semantic intent:
+Different operating systems have varying support for badge types. Since the OS ultimately controls badge rendering, it is the user agent that communicates the correct semantic intent:
 
 * **Flag support**: Some platforms do not natively support "flag" badges (badges without numbers). In such cases, user agents communicate to the OS using the closest available representation that conveys badge presence (such as a generic symbol or the number "1") rather than requesting badge clearing.
 * **Number support**: Some platforms might not support numbered badges. In such cases, user agents can communicate the badge to the OS as a flag representation.

--- a/explainer.md
+++ b/explainer.md
@@ -443,7 +443,7 @@ At any time, the badge for a specific document or app, if it is set, may be eith
 
 The model does not allow a badge to be a negative integer, or the integer value 0 (setting the badge to 0 is equivalent to clearing the badge).
 
-**Important distinction**: A "flag" badge should display a visual indicator to the user (such as a dot or circle), whereas a cleared badge (value 0 or calling `clearAppBadge()`) should display nothing. These are semantically different states, and platforms must not treat a request to set a "flag" as equivalent to clearing the badge.
+**Important distinction**: A "flag" badge generally displays a visual indicator to the user (such as a dot or circle), whereas a cleared badge (value 0 or calling `clearAppBadge()`) clears it. These are semantically different states, and platforms generally won't treat a request to set a "flag" as equivalent to clearing the badge.
 
 The user agent is allowed to clear all badges on an origin whenever there are no foreground pages open on the origin (the intention of this is so that when the user agent quits, it does not need to serialize all the badge data and restore it on start-up; sites should re-apply the badge when they open).
 

--- a/index.html
+++ b/index.html
@@ -145,14 +145,18 @@
           The special value <dfn>"nothing"</dfn>:
         </dt>
         <dd>
-          Indicates that there is no badge currently [=badge/set=].
+          Indicates that there is no badge currently [=badge/set=]. When a
+          [=badge=] has this value, no visual indicator should be displayed
+          to the user.
         </dd>
         <dt>
           The special value <dfn>"flag"</dfn>:
         </dt>
         <dd>
-          Indicates that the badge is [=badge/set=], but contains no specific
-          value.
+          Indicates that the badge is [=badge/set=] and should be displayed
+          to the user, but contains no specific numerical value. This is
+          distinct from [="nothing"=] in that a visual indicator should be
+          shown to the user to indicate the presence of the badge.
         </dd>
         <dt>
           A <dfn>number</dfn> value:
@@ -192,7 +196,10 @@
       <p>
         When the [=badge=] is [=badge/set=] to [="flag"=], the [=user agent=]
         or operating system SHOULD display an indicator with a non-specific
-        symbol (for example, a colored circle).
+        symbol (for example, a colored circle). If the platform does not support
+        displaying a [="flag"=] badge, the [=user agent=] SHOULD display the
+        badge using the closest available representation that indicates the
+        presence of a badge, rather than [=badge/clearing=] the badge entirely.
       </p>
       <p>
         When a [=badge=]'s value is [=badge/set=] to [="nothing"=], the [=user
@@ -220,7 +227,37 @@
         </li>
         <li>MAY treat a [=number=] [=badge/value=] as [="flag"=], or whatever
         representation is most appropriate for the platform, if the platform
-        does not support displaying [=numbers=] in a [=badge=].
+        does not support displaying [=numbers=] in a [=badge=]. Similarly, if
+        the platform does not support [="flag"=] badges, it MAY represent
+        [="flag"=] using a [=number=] or other appropriate visual indicator,
+        but MUST NOT [=badge/clear=] the badge when [="flag"=] is requested.
+        </li>
+      </ul>
+      <h3>
+        Implementation considerations for platform limitations
+      </h3>
+      <p>
+        Different operating systems have varying capabilities for displaying badges.
+        When communicating badge information to the operating system, [=user agents=]
+        SHOULD preserve the semantic intent of the badge request:
+      </p>
+      <ul>
+        <li>When the operating system does not support [="flag"=] badges, the
+        [=user agent=] SHOULD communicate to the OS using the closest available
+        representation that conveys the presence of a badge (such as a minimal
+        number or generic symbol) rather than communicating a request to
+        [=badge/clear=] the badge.
+        </li>
+        <li>When the operating system does not support [=number=] badges, the
+        [=user agent=] MAY communicate the badge to the OS as a [="flag"=]
+        representation.
+        </li>
+        <li>The [=user agent=] MUST NOT interpret a request to set a [="flag"=]
+        as equivalent to [=badge/clearing=] the badge when communicating with
+        the operating system.
+        </li>
+        <li>The ultimate display behavior is controlled by the operating system
+        and may be further modified by user settings or system conventions.
         </li>
       </ul>
     </section>

--- a/index.html
+++ b/index.html
@@ -257,7 +257,7 @@
         the operating system.
         </li>
         <li>The ultimate display behavior is controlled by the operating system
-        and may be further modified by user settings or system conventions.
+        and MAY be further modified by user settings or system conventions.
         </li>
       </ul>
     </section>

--- a/index.html
+++ b/index.html
@@ -244,7 +244,7 @@
       <ul>
         <li>When the operating system does not support [="flag"=] badges, the
         [=user agent=] SHOULD communicate to the OS using the closest available
-        representation that conveys the presence of a badge (such as a the number "1"
+        representation that conveys the presence of a badge (such as the number "1"
         or generic symbol) rather than communicating a request to
         [=badge/clear=] the badge.
         </li>

--- a/index.html
+++ b/index.html
@@ -199,7 +199,7 @@
         symbol (for example, a colored circle). If the platform does not support
         displaying a [="flag"=] badge, the [=user agent=] SHOULD display the
         badge using the closest available representation that indicates the
-        presence of a badge, rather than [=badge/clearing=] the badge entirely.
+        presence of a badge (e.g., the value "1"), rather than [=badge/clearing=] the badge entirely.
       </p>
       <p>
         When a [=badge=]'s value is [=badge/set=] to [="nothing"=], the [=user

--- a/index.html
+++ b/index.html
@@ -261,6 +261,8 @@
       </h3>
       <p>
         Different operating systems have varying capabilities for displaying badges.
+        The ultimate display behavior is controlled by the operating system
+        and might be further modified by user settings or system conventions.
         When communicating badge information to the operating system, [=user agents=]
         SHOULD preserve the semantic intent of the badge request:
       </p>

--- a/index.html
+++ b/index.html
@@ -264,11 +264,6 @@
         When communicating badge information to the operating system, [=user agents=]
         SHOULD preserve the semantic intent of the badge request:
       </p>
-      <aside class="note">
-        <p>The ultimate display behavior is controlled by the operating system
-        and might be further modified by user settings or system conventions.
-        </p>
-      </aside>
       <ul>
         <li>When the operating system does not support [="flag"=] badges, the
         [=user agent=] SHOULD communicate to the OS using the closest available

--- a/index.html
+++ b/index.html
@@ -165,18 +165,18 @@
         </dt>
         <dd>
           Indicates that there is no badge currently [=badge/set=]. When a
-          [=badge=] has this value, no visual indicator should be displayed
-          to the user.
+          [=badge=] has this value, no visual indicator should be displayed to
+          the user.
         </dd>
         <dt>
           The special value <dfn class="export" data-dfn-for=
           "badge">"flag"</dfn>:
         </dt>
         <dd>
-          Indicates that the badge is [=badge/set=] and should be displayed
-          to the user, but contains no specific numerical value. This is
-          distinct from [="nothing"=] in that a visual indicator should be
-          shown to the user to indicate the presence of the badge.
+          Indicates that the badge is [=badge/set=] and should be displayed to
+          the user, but contains no specific numerical value. This is distinct
+          from [=badge/"nothing"=] in that a visual indicator should be shown
+          to the user to indicate the presence of the badge.
         </dd>
         <dt>
           A <dfn class="export" data-dfn-for="badge">number</dfn> value:
@@ -217,12 +217,13 @@
         "[=notifications=]" permission.
       </p>
       <p>
-        When the [=badge=] is [=badge/set=] to [="flag"=], the [=user agent=]
-        or operating system SHOULD display an indicator with a non-specific
-        symbol (for example, a colored circle). If the platform does not support
-        displaying a [="flag"=] badge, the [=user agent=] SHOULD display the
-        badge using the closest available representation that indicates the
-        presence of a badge (e.g., the value "1"), rather than [=badge/clearing=] the badge entirely.
+        When the [=badge=] is [=badge/set=] to [=badge/"flag"=], the [=user
+        agent=] or operating system SHOULD display an indicator with a
+        non-specific symbol (for example, a colored circle). If the platform
+        does not support displaying a [=badge/"flag"=] badge, the [=user
+        agent=] SHOULD display the badge using the closest available
+        representation that indicates the presence of a badge (e.g., the value
+        "1"), rather than [=badge/clearing=] the badge entirely.
       </p>
       <p>
         When a [=badge=]'s value is [=badge/set=] to [=badge/"nothing"=], the
@@ -248,38 +249,40 @@
         preferences. For example, the [=badge/value=] '7' should be displayed
         as '7' in the locale 'en' (English) but as '٧' in 'ar' (Arabic).
         </li>
-        <li>MAY treat a [=number=] [=badge/value=] as [="flag"=], or whatever
-        representation is most appropriate for the platform, if the platform
-        does not support displaying [=numbers=] in a [=badge=]. Similarly, if
-        the platform does not support [="flag"=] badges, it MAY represent
-        [="flag"=] using a [=number=] or other appropriate visual indicator,
-        but MUST NOT [=badge/clear=] the badge when [="flag"=] is requested.
+        <li>MAY treat a [=badge/number=] [=badge/value=] as [=badge/"flag"=],
+        or whatever representation is most appropriate for the platform, if the
+        platform does not support displaying [=badge/"number"|numbers=] in a
+        [=badge=]. Similarly, if the platform does not support [=badge/"flag"=]
+        badges, it MAY represent [=badge/"flag"=] using a [=badge/number=] or
+        other appropriate visual indicator, but MUST NOT [=badge/clear=] the
+        badge when [=badge/"flag"=] is requested.
         </li>
       </ul>
       <h3>
         Implementation considerations for platform limitations
       </h3>
       <p>
-        Different operating systems have varying capabilities for displaying badges.
-        The ultimate display behavior is controlled by the operating system
-        and might be further modified by user settings or system conventions.
-        When communicating badge information to the operating system, [=user agents=]
-        SHOULD preserve the semantic intent of the badge request:
+        Different operating systems have varying capabilities for displaying
+        badges. The ultimate display behavior is controlled by the operating
+        system and might be further modified by user settings or system
+        conventions. When communicating badge information to the operating
+        system, [=user agents=] SHOULD preserve the semantic intent of the
+        badge request:
       </p>
       <ul>
-        <li>When the operating system does not support [="flag"=] badges, the
-        [=user agent=] SHOULD communicate to the OS using the closest available
-        representation that conveys the presence of a badge (such as the number "1"
-        or generic symbol) rather than communicating a request to
-        [=badge/clear=] the badge.
+        <li>When the operating system does not support [=badge/"flag"=] badges,
+        the [=user agent=] SHOULD communicate to the OS using the closest
+        available representation that conveys the presence of a badge (such as
+        the number "1" or generic symbol) rather than communicating a request
+        to [=badge/clear=] the badge.
         </li>
-        <li>When the operating system does not support [=number=] badges, the
-        [=user agent=] MAY communicate the badge to the OS as a [="flag"=]
-        representation.
+        <li>When the operating system does not support [=badge/number=] badges,
+        the [=user agent=] MAY communicate the badge to the OS as a
+        [=badge/"flag"=] representation.
         </li>
-        <li>The [=user agent=] MUST NOT interpret a request to set a [="flag"=]
-        as equivalent to [=badge/clearing=] the badge when communicating with
-        the operating system.
+        <li>The [=user agent=] MUST NOT interpret a request to set a
+        [=badge/"flag"=] as equivalent to [=badge/clearing=] the badge when
+        communicating with the operating system.
         </li>
       </ul>
     </section>

--- a/index.html
+++ b/index.html
@@ -244,8 +244,8 @@
       <ul>
         <li>When the operating system does not support [="flag"=] badges, the
         [=user agent=] SHOULD communicate to the OS using the closest available
-        representation that conveys the presence of a badge (such as a minimal
-        number or generic symbol) rather than communicating a request to
+        representation that conveys the presence of a badge (such as a the number "1"
+        or generic symbol) rather than communicating a request to
         [=badge/clear=] the badge.
         </li>
         <li>When the operating system does not support [=number=] badges, the


### PR DESCRIPTION
Closes #102

This pull request clarifies and strengthens the distinction between "flag" badges (a visual indicator without a number) and cleared badges ("nothing") in both the specification and explainer documentation. It also provides detailed guidance for how user agents should handle platform limitations to ensure consistent semantic behavior across different operating systems.

**Clarification of badge semantics:**

* Updated `index.html` and `explainer.md` to explicitly state that a "flag" badge should always display a visual indicator, and that this is semantically distinct from a cleared badge (which should display nothing). Platforms must not treat a "flag" as equivalent to clearing the badge. [[1]](diffhunk://#diff-e67a39255f4b3dddb1fcf5064c57589e9f3e0a9cc58d46d0293b09322287097aR446-R447) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L148-R159)

**Platform limitations and implementation guidance:**

* Added new sections to both `index.html` and `explainer.md` describing how user agents should handle cases where the operating system does not support certain badge types. User agents must preserve the semantic intent of the badge (flag vs. nothing) and use the closest available representation, but must never clear the badge when a flag is requested. [[1]](diffhunk://#diff-e67a39255f4b3dddb1fcf5064c57589e9f3e0a9cc58d46d0293b09322287097aR492-R502) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L195-R202) [[3]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L223-R260)

This change (choose at least one, delete ones that don't apply):

* Adds new normative requirements

Implementation commitment (delete if not making normative changes):

* [ ] Modified Web platform tests (link)
* [ ] [WebKit](https://bugs.webkit.org/show_bug.cgi?id=254884)
* [ ] Chromium (https://bugs.chromium.org/)
* [ ] Gecko (http://bugzilla.mozilla.org)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/badging/pull/123.html" title="Last updated on Oct 2, 2025, 6:33 AM UTC (50de203)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/badging/123/f04f961...50de203.html" title="Last updated on Oct 2, 2025, 6:33 AM UTC (50de203)">Diff</a>