### PR TITLE
Chore: Bring Jay Harris out of retirement

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
           name: "Jay Harris",
           company: "Brave Software, Inc.",
           companyURL: "https://brave.com",
-          w3cid: 39125
+          w3cid: 111473
         },
         {
           name: "Marcos Cáceres",


### PR DESCRIPTION
Brings Jay back as primary editor of the spec.

This pull request updates the list of editors in the `index.html` file. The main change is updating the affiliation of Jay Harris, moving him from a retired editor at Google to an active editor at Brave Software, Inc.

Editor updates:

* Added Jay Harris as an active editor with affiliation to Brave Software, Inc. and removed his previous listing as a retired editor from Google Inc. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R23-R28) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L34-L39)

This change (choose at least one, delete ones that don't apply):

* Is a "chore" (metadata, formatting, fixing warnings, etc).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/badging/pull/125.html" title="Last updated on Sep 25, 2025, 10:08 AM UTC (0cd006c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/badging/125/6ca1073...0cd006c.html" title="Last updated on Sep 25, 2025, 10:08 AM UTC (0cd006c)">Diff</a>