### PR TITLE
Chore: Simplify Badging API to app-only scope

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -442,6 +442,7 @@ The API allows `set()`ing an `unsigned long long`. When presenting this value, i
 ### Index of Considered Alternatives
 - The API being a more general API that [sets a badge on a URL scope](https://github.com/w3c/badging/issues/55), applying to all apps within that scope.
 - Setting an app badge badges [app associated with the current document's linked manifest](https://github.com/w3c/badging/issues/55), as opposed to any app that scopes this document.
+- A single URL-scoped API that sets both the document and app badges at the same time (applying to all documents within the URL scope).
 - A [declarative API](#Couldnt-this-be-a-declarative-API-so-it-would-work-without-JavaScript).
 - Exposing the badging API [elsewhere](#Why-is-this-API-attached-to-window-instead-of-navigator-or-notifications).
 - Supporting [non-integers](#Why-limit-support-to-just-an-integer-What-about-other-characters).

--- a/explainer.md
+++ b/explainer.md
@@ -440,6 +440,7 @@ full power of showing a native badge.
 The API allows `set()`ing an `unsigned long long`. When presenting this value, it should be formatted according to the user's locale settings.
 
 ### Index of Considered Alternatives
+- An API to set the badge on a browser tab. 
 - The API being a more general API that [sets a badge on a URL scope](https://github.com/w3c/badging/issues/55), applying to all apps within that scope.
 - Setting an app badge badges [app associated with the current document's linked manifest](https://github.com/w3c/badging/issues/55), as opposed to any app that scopes this document.
 - A single URL-scoped API that sets both the document and app badges at the same time (applying to all documents within the URL scope).


### PR DESCRIPTION
In the Explainer: 

- Remove navigator.setClientBadge() and clearClientBadge() methods
- Remove document/tab badging functionality and examples
- Focus API exclusively on app badging with setAppBadge()/clearAppBadge()
- Update usage examples to demonstrate app badging only
- Simplify feature detection section
- Remove references to dual API approach
- Update design questions to reflect app-only focus

This pull request refactors the Badging API explainer to simplify the API surface, remove the document badge functionality, and clarify the API's scope and usage. The changes focus the explainer on the app badge API, update usage examples, and clean up outdated references and feature detection logic. The result is a clearer, more concise document that describes only the app-level badging API.

**API Surface and Scope Simplification**
* Removed all references to the document badge API (`setClientBadge` and `clearClientBadge`) and updated the explainer to describe only the app badge API (`setAppBadge` and `clearAppBadge`). [[1]](diffhunk://#diff-e67a39255f4b3dddb1fcf5064c57589e9f3e0a9cc58d46d0293b09322287097aL47-R49) [[2]](diffhunk://#diff-e67a39255f4b3dddb1fcf5064c57589e9f3e0a9cc58d46d0293b09322287097aL164-R147) [[3]](diffhunk://#diff-e67a39255f4b3dddb1fcf5064c57589e9f3e0a9cc58d46d0293b09322287097aL456-L460)
* Updated feature detection logic and examples to reflect the removal of the document badge, focusing on checking for `navigator.setAppBadge` only. [[1]](diffhunk://#diff-e67a39255f4b3dddb1fcf5064c57589e9f3e0a9cc58d46d0293b09322287097aL402-R343) [[2]](diffhunk://#diff-e67a39255f4b3dddb1fcf5064c57589e9f3e0a9cc58d46d0293b09322287097aL219-L227)

**Usage and Examples**
* Rewrote usage examples to demonstrate only app badge usage, including service worker context, and removed all document badge fallback logic. [[1]](diffhunk://#diff-e67a39255f4b3dddb1fcf5064c57589e9f3e0a9cc58d46d0293b09322287097aL164-R147) [[2]](diffhunk://#diff-e67a39255f4b3dddb1fcf5064c57589e9f3e0a9cc58d46d0293b09322287097aL219-L227) [[3]](diffhunk://#diff-e67a39255f4b3dddb1fcf5064c57589e9f3e0a9cc58d46d0293b09322287097aL239-R169)

**Design and Rationale**
* Updated the rationale and design questions to reflect the new API scope, clarifying why the API is attached to `navigator` and why a declarative approach is less suitable for the app API. [[1]](diffhunk://#diff-e67a39255f4b3dddb1fcf5064c57589e9f3e0a9cc58d46d0293b09322287097aL35-R36) [[2]](diffhunk://#diff-e67a39255f4b3dddb1fcf5064c57589e9f3e0a9cc58d46d0293b09322287097aL514-R412)

**Cleanup and Consistency**
* Removed outdated sections and examples related to document badges, such as UI treatment and alternative API designs, and improved consistency in terminology and formatting. [[1]](diffhunk://#diff-e67a39255f4b3dddb1fcf5064c57589e9f3e0a9cc58d46d0293b09322287097aL47-R49) [[2]](diffhunk://#diff-e67a39255f4b3dddb1fcf5064c57589e9f3e0a9cc58d46d0293b09322287097aL481-R387) [[3]](diffhunk://#diff-e67a39255f4b3dddb1fcf5064c57589e9f3e0a9cc58d46d0293b09322287097aL555-L557)

**Minor Corrections**
* Fixed minor typos and improved markdown formatting for clarity and accessibility. [[1]](diffhunk://#diff-e67a39255f4b3dddb1fcf5064c57589e9f3e0a9cc58d46d0293b09322287097aL13) [[2]](diffhunk://#diff-e67a39255f4b3dddb1fcf5064c57589e9f3e0a9cc58d46d0293b09322287097aL35-R36)

This change (choose at least one, delete ones that don't apply):

* Is a "chore" (metadata, formatting, fixing warnings, etc).
